### PR TITLE
Fixed 1 spelling error in preferences pane

### DIFF
--- a/html/config.js
+++ b/html/config.js
@@ -190,7 +190,7 @@ window.onload = function() {
             html += '</table>';
         });
         if (Object.keys(allPrefs).length > 0) {
-            html += '<h2>Miscelaneous</h2><table>';
+            html += '<h2>Miscellaneous</h2><table>';
             Object.keys(allPrefs).forEach(function(name) {
                 var val = allPrefs[name];
                 addHtmlFor(name, val);


### PR DESCRIPTION
Noticed the "Miscellaneous" header was spelled wrong so I forked this submodule. It looks like there isn't anything else misspelled in the preferences pane.
